### PR TITLE
Overridable primary_key on ActiveStorage attachment macros

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -63,4 +63,8 @@
 
     *Yogesh Khater*
 
+*   Allow overriding of `primary_key` on `has_one_attached` and `has_many_attached` relations.
+
+    *Jonah George*
+
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -103,7 +103,7 @@ module ActiveStorage
       # When renaming classes that use <tt>has_one_attached</tt>, make sure to also update the class names in the
       # <tt>active_storage_attachments.record_type</tt> polymorphic type column of
       # the corresponding rows.
-      def has_one_attached(name, dependent: :purge_later, service: nil, strict_loading: false)
+      def has_one_attached(name, dependent: :purge_later, service: nil, strict_loading: false, attachment_primary_key: nil)
         ActiveStorage::Blob.validate_service_configuration(service, self, name) unless service.is_a?(Proc)
 
         generated_association_methods.class_eval <<-CODE, __FILE__, __LINE__ + 1
@@ -123,7 +123,7 @@ module ActiveStorage
           end
         CODE
 
-        has_one :"#{name}_attachment", -> { where(name: name) }, class_name: "ActiveStorage::Attachment", as: :record, inverse_of: :record, dependent: :destroy, strict_loading: strict_loading
+        has_one :"#{name}_attachment", -> { where(name: name) }, class_name: "ActiveStorage::Attachment", as: :record, inverse_of: :record, dependent: :destroy, strict_loading: strict_loading, primary_key: attachment_primary_key
         has_one :"#{name}_blob", through: :"#{name}_attachment", class_name: "ActiveStorage::Blob", source: :blob, strict_loading: strict_loading
 
         scope :"with_attached_#{name}", -> {
@@ -203,7 +203,7 @@ module ActiveStorage
       # When renaming classes that use <tt>has_many</tt>, make sure to also update the class names in the
       # <tt>active_storage_attachments.record_type</tt> polymorphic type column of
       # the corresponding rows.
-      def has_many_attached(name, dependent: :purge_later, service: nil, strict_loading: false)
+      def has_many_attached(name, dependent: :purge_later, service: nil, strict_loading: false, attachments_primary_key: nil)
         ActiveStorage::Blob.validate_service_configuration(service, self, name) unless service.is_a?(Proc)
 
         generated_association_methods.class_eval <<-CODE, __FILE__, __LINE__ + 1
@@ -225,7 +225,7 @@ module ActiveStorage
           end
         CODE
 
-        has_many :"#{name}_attachments", -> { where(name: name) }, as: :record, class_name: "ActiveStorage::Attachment", inverse_of: :record, dependent: :destroy, strict_loading: strict_loading
+        has_many :"#{name}_attachments", -> { where(name: name) }, as: :record, class_name: "ActiveStorage::Attachment", inverse_of: :record, dependent: :destroy, strict_loading: strict_loading, primary_key: attachments_primary_key
         has_many :"#{name}_blobs", through: :"#{name}_attachments", class_name: "ActiveStorage::Blob", source: :blob, strict_loading: strict_loading
 
         scope :"with_attached_#{name}", -> {


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

My application retrofits a legacy database schema which uses a mixture of integer and uuid primary keys for models. Because the primary key of `ActiveStorage::Blob` must be fixed as it is a polymorphic relationship, this causes problems when attempting to attach blobs to models which do not adhere to its foreign key type.


### Detail

This Pull Request changes the `has_one_attached` and `has_many_attached` macros to support optional `attachment_primary_key` and `attachments_primary_key` keyword arguments (respectively) for customizing the `primary_key` attribute of `has_one :"#{name}_attachment"` and `has_many :"#{name}_attachments"` relationships.

```ruby
# == Schema Information
#
# Table name: users
#
#  id       :uuid       not null, primary key
#  name     :string(50)
#
class User < ApplicationRecord
  has_one_attached :profile_picture
end

# == Schema Information
#
# Table name: posts
#
#  id       :integer       not null, primary key
#  title    :string(50)
#  post_id  :uuid        <-- newly created column for compatibility with ActiveStorage::Blob
#
class Post < ApplicationRecord
  has_many_attached :images, attachments_primary_key: "post_id"
end
```

```ruby
User.eager_load(:profile_picture_attachment).first

SELECT 
  "users"."id" AS t0_r0, 
  "users"."name" AS t0_r1, 
  "active_storage_attachments"."id" AS t1_r0, 
  "active_storage_attachments"."name" AS t1_r1, 
  "active_storage_attachments"."record_type" AS t1_r2, 
  "active_storage_attachments"."record_id" AS t1_r3, 
  "active_storage_attachments"."blob_id" AS t1_r4, 
  "active_storage_attachments"."created_at" AS t1_r5 
FROM "users" 
LEFT OUTER JOIN "active_storage_attachments" 
  ON "active_storage_attachments"."record_type" = ? 
  AND "active_storage_attachments"."name" = ? 
  AND "active_storage_attachments"."record_id" = "users"."id" # Existing behavior
ORDER BY "users"."id" ASC 
LIMIT ?
```

```ruby
> Post.eager_load(:images_attachments).first

SELECT 
  "posts"."id" AS t0_r0, 
  "posts"."title" AS t0_r1, 
  "posts"."post_id" AS t0_r2, 
  "posts"."user_id" AS t0_r3, 
  "active_storage_attachments"."id" AS t1_r0, 
  "active_storage_attachments"."name" AS t1_r1, 
  "active_storage_attachments"."record_type" AS t1_r2, 
  "active_storage_attachments"."record_id" AS t1_r3, 
  "active_storage_attachments"."blob_id" AS t1_r4, 
  "active_storage_attachments"."created_at" AS t1_r5 
FROM "posts" 
LEFT OUTER JOIN "active_storage_attachments" 
  ON "active_storage_attachments"."record_type" = ? 
  AND "active_storage_attachments"."name" = ? 
  AND "active_storage_attachments"."record_id" = "posts"."post_id" # New column override
WHERE "posts"."id" = ? 
ORDER BY "posts"."id" ASC
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
